### PR TITLE
Small RTL styling fix

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -167,7 +167,9 @@
   font-weight: 100;
 }
 
-
+[dir="rtl"] .adhs-container .adhs-modal .adhs-list .adhs-list-item .adhs-number {
+  padding: 6px 11px 0px 11px;
+}
 
 .adhs-container .adhs-modal .adhs-list .adhs-list-item .adhs-instruction {
   font-size: 19px;


### PR DESCRIPTION
Small fix for RTL

Before:
<img src="https://github.com/user-attachments/assets/3b555413-6a2e-4421-93d2-df5b2f28af91" width="200">

After
<img src="https://github.com/user-attachments/assets/bf596692-7159-48ec-9f42-afaf08546861" width="200">


