### PR TITLE
Class adhs-list-button-image-right has same margin as adhs-list-button-image-left (5px)

### DIFF
--- a/dist/add-to-homescreen.min.css
+++ b/dist/add-to-homescreen.min.css
@@ -242,7 +242,7 @@
   .adhs-list-button
   .adhs-list-button-image-left {
   position: relative;
-  margin: 0 5px 0px 0px;
+  margin: 0 5px 0 0;
   top: 2px;
 }
 
@@ -253,6 +253,7 @@
   .adhs-list-button
   .adhs-list-button-image-right {
   position: relative;
+  margin: 0 0 0 5px;
   top: 2px;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -243,7 +243,7 @@
   .adhs-list-button
   .adhs-list-button-image-left {
   position: relative;
-  margin: 0 5px 0px 0px;
+  margin: 0 5px 0 0;
   top: 2px;
 }
 
@@ -254,6 +254,7 @@
   .adhs-list-button
   .adhs-list-button-image-right {
   position: relative;
+  margin: 0 0 0 5px;
   top: 2px;
 }
 


### PR DESCRIPTION
### Old
<img width="172" alt="Snímek obrazovky 2024-09-29 v 16 25 49" src="https://github.com/user-attachments/assets/0e7837a7-8891-455f-a767-1c96ccc8f9f6">

### New
<img width="183" alt="Snímek obrazovky 2024-09-29 v 16 25 32" src="https://github.com/user-attachments/assets/94876698-7381-4dac-afbc-6c5052ad218b">
