### PR TITLE
Updated wording to fit with danish iOS

### DIFF
--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -1,8 +1,8 @@
 {
-  "Add to Home Screen": "Tilføj til startskærm",
+  "Add to Home Screen": "Føj til hjemmeskærm",
   "Add To Dock": "Tilføj til dock",
   "An icon will be added to your Dock so you can quickly access this website.": "Et ikon vil blive tilføjet til din dock, så du hurtigt kan få adgang til dette website.",
-  "An icon will be added to your home screen so you can quickly access this website.": "Et ikon vil blive tilføjet til din startskærm, så du hurtigt kan få adgang til dette website.",
+  "An icon will be added to your home screen so you can quickly access this website.": "Et ikon vil blive tilføjet til din hjemmeskærm, så du hurtigt kan få adgang til dette website.",
   "An icon will be added to your Taskbar so you can quickly access this website.": "Et ikon vil blive tilføjet til din proceslinje, så du hurtigt kan få adgang til dette website.",
   "Install": "Installer",
   "Install %s": "Installer %s",


### PR DESCRIPTION
In danish iOS it is called "hjemmeskærm" (home screen) instead of "startskærm" (start screen)